### PR TITLE
Extend API to write user-defined metadata to avro file

### DIFF
--- a/lang/c++/api/DataFile.hh
+++ b/lang/c++/api/DataFile.hh
@@ -78,9 +78,6 @@ class AVRO_DECL DataFileWriterBase : boost::noncopyable {
     static std::unique_ptr<OutputStream> makeStream(const char* filename);
     static DataFileSync makeSync();
 
-    void writeHeader();
-    void setMetadata(const std::string& key, const std::string& value);
-
     /**
      * Generates a sync marker in the file.
      */
@@ -92,6 +89,10 @@ class AVRO_DECL DataFileWriterBase : boost::noncopyable {
     void init(const ValidSchema &schema, size_t syncInterval, const Codec &codec);
 
 public:
+
+    void writeHeader();
+    void setMetadata(const std::string& key, const std::string& value);
+
     /**
      * Returns the current encoder for this writer.
      */
@@ -140,6 +141,7 @@ public:
  */
 template <typename T>
 class DataFileWriter : boost::noncopyable {
+    bool metadata_is_written_ = false;
     std::unique_ptr<DataFileWriterBase> base_;
 public:
     /**
@@ -157,6 +159,10 @@ public:
      * Writes the given piece of data into the file.
      */
     void write(const T& datum) {
+        if (!metadata_is_written_) {
+            metadata_is_written_ = true;
+            writeHeader();
+        }
         base_->syncIfNeeded();
         avro::encode(base_->encoder(), datum);
         base_->incr();
@@ -177,6 +183,13 @@ public:
      * Flushes any unwritten data into the file.
      */
     void flush() { base_->flush(); }
+
+    void setMetadata(const std::string& key, const std::string& value) { base_->setMetadata(key, value); }
+
+    void writeHeader() { 
+        metadata_is_written_ = true;
+        base_->writeHeader(); 
+    }
 };
 
 /**

--- a/lang/c++/impl/DataFile.cc
+++ b/lang/c++/impl/DataFile.cc
@@ -117,9 +117,6 @@ void DataFileWriterBase::init(const ValidSchema &schema, size_t syncInterval, co
       throw Exception(boost::format("Unknown codec: %1%") % codec);
     }
     setMetadata(AVRO_SCHEMA_KEY, schema.toJson(false));
-
-    writeHeader();
-    encoderPtr_->init(*buffer_);
 }
 
 
@@ -279,6 +276,7 @@ void DataFileWriterBase::writeHeader()
     avro::encode(*encoderPtr_, metadata_);
     avro::encode(*encoderPtr_, sync_);
     encoderPtr_->flush();
+    encoderPtr_->init(*buffer_);
 }
 
 void DataFileWriterBase::setMetadata(const string& key, const string& value)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
