### PR TITLE
Add configurable max schema nesting depth to prevent stack overflow

### DIFF
--- a/lang/c++/api/Compiler.hh
+++ b/lang/c++/api/Compiler.hh
@@ -38,7 +38,8 @@ class AVRO_DECL ValidSchema;
 /// ValidSchema object.  Throws if the schema cannot be compiled to a valid
 /// schema
 
-AVRO_DECL void compileJsonSchema(std::istream &is, ValidSchema &schema);
+AVRO_DECL void compileJsonSchema(std::istream &is, ValidSchema &schema,
+    size_t maxDepth = 0);
 
 /// Non-throwing version of compileJsonSchema.
 ///
@@ -48,13 +49,17 @@ AVRO_DECL void compileJsonSchema(std::istream &is, ValidSchema &schema);
 AVRO_DECL bool compileJsonSchema(std::istream &is, ValidSchema &schema,
     std::string &error);
 
-AVRO_DECL ValidSchema compileJsonSchemaFromStream(InputStream& is);
+AVRO_DECL ValidSchema compileJsonSchemaFromStream(InputStream& is,
+    size_t maxDepth = 0);
 
-AVRO_DECL ValidSchema compileJsonSchemaFromMemory(const uint8_t* input, size_t len);
+AVRO_DECL ValidSchema compileJsonSchemaFromMemory(const uint8_t* input, size_t len,
+    size_t maxDepth = 0);
 
-AVRO_DECL ValidSchema compileJsonSchemaFromString(const char* input);
+AVRO_DECL ValidSchema compileJsonSchemaFromString(const char* input,
+    size_t maxDepth = 0);
 
-AVRO_DECL ValidSchema compileJsonSchemaFromString(const std::string& input);
+AVRO_DECL ValidSchema compileJsonSchemaFromString(const std::string& input,
+    size_t maxDepth = 0);
 
 AVRO_DECL ValidSchema compileJsonSchemaFromFile(const char* filename);
 

--- a/lang/c++/api/DataFile.hh
+++ b/lang/c++/api/DataFile.hh
@@ -203,6 +203,7 @@ class AVRO_DECL DataFileReaderBase : boost::noncopyable {
 
     Metadata metadata_;
     DataFileSync sync_;
+    size_t maxSchemaDepth_;
 
     // for compressed buffer
     std::unique_ptr<boost::iostreams::filtering_istream> os_;
@@ -234,9 +235,10 @@ public:
      * This function should be called exactly once after constructing
      * the DataFileReaderBase object.
      */
-    DataFileReaderBase(const char* filename);
+    DataFileReaderBase(const char* filename, size_t maxSchemaDepth = 0);
 
-    DataFileReaderBase(std::unique_ptr<InputStream> inputStream);
+    DataFileReaderBase(std::unique_ptr<InputStream> inputStream,
+        size_t maxSchemaDepth = 0);
 
     /**
      * Initializes the reader so that the reader and writer schemas

--- a/lang/c++/api/ValidSchema.hh
+++ b/lang/c++/api/ValidSchema.hh
@@ -39,8 +39,8 @@ class AVRO_DECL Schema;
 
 class AVRO_DECL ValidSchema {
 public:
-    explicit ValidSchema(const NodePtr &root);
-    explicit ValidSchema(const Schema &schema);
+    explicit ValidSchema(const NodePtr &root, size_t maxDepth = 0);
+    explicit ValidSchema(const Schema &schema, size_t maxDepth = 0);
     ValidSchema();
 
     void setSchema(const Schema &schema);

--- a/lang/c++/impl/Compiler.cc
+++ b/lang/c++/impl/Compiler.cc
@@ -66,7 +66,8 @@ static NodePtr makePrimitive(const string& t)
     }
 }
 
-static NodePtr makeNode(const json::Entity& e, SymbolTable& st, const string &ns);
+static NodePtr makeNode(const json::Entity& e, SymbolTable& st, const string &ns,
+    size_t depth = 0, size_t maxDepth = 0);
 
 template <typename T>
 concepts::SingleAttribute<T> asSingleAttribute(const T& t)
@@ -292,13 +293,14 @@ static GenericDatum makeGenericDatum(NodePtr n,
 }
 
 
-static Field makeField(const Entity& e, SymbolTable& st, const string& ns)
+static Field makeField(const Entity& e, SymbolTable& st, const string& ns,
+    size_t depth, size_t maxDepth)
 {
     const Object& m = e.objectValue();
     const string& n = getStringField(e, m, "name");
     Object::const_iterator it = findField(e, m, "type");
     map<string, Entity>::const_iterator it2 = m.find("default");
-    NodePtr node = makeNode(it->second, st, ns);
+    NodePtr node = makeNode(it->second, st, ns, depth, maxDepth);
     if (containsField(m, "doc")) {
         node->setDoc(getDocField(e, m));
     }
@@ -310,14 +312,15 @@ static Field makeField(const Entity& e, SymbolTable& st, const string& ns)
 // Extended makeRecordNode (with doc).
 static NodePtr makeRecordNode(const Entity& e, const Name& name,
                               const string* doc, const Object& m,
-                              SymbolTable& st, const string& ns) {
+                              SymbolTable& st, const string& ns,
+                              size_t depth, size_t maxDepth) {
     const Array& v = getArrayField(e, m, "fields");
     concepts::MultiAttribute<string> fieldNames;
     concepts::MultiAttribute<NodePtr> fieldValues;
     vector<GenericDatum> defaultValues;
 
     for (Array::const_iterator it = v.begin(); it != v.end(); ++it) {
-        Field f = makeField(*it, st, ns);
+        Field f = makeField(*it, st, ns, depth, maxDepth);
         fieldNames.add(f.name);
         fieldValues.add(f.schema);
         defaultValues.push_back(f.defaultValue);
@@ -411,11 +414,11 @@ static NodePtr makeFixedNode(const Entity& e,
 }
 
 static NodePtr makeArrayNode(const Entity& e, const Object& m,
-    SymbolTable& st, const string& ns)
+    SymbolTable& st, const string& ns, size_t depth, size_t maxDepth)
 {
     Object::const_iterator it = findField(e, m, "items");
     NodePtr node = NodePtr(new NodeArray(
-        asSingleAttribute(makeNode(it->second, st, ns))));
+        asSingleAttribute(makeNode(it->second, st, ns, depth + 1, maxDepth))));
     if (containsField(m, "doc")) {
         node->setDoc(getDocField(e, m));
     }
@@ -423,12 +426,12 @@ static NodePtr makeArrayNode(const Entity& e, const Object& m,
 }
 
 static NodePtr makeMapNode(const Entity& e, const Object& m,
-    SymbolTable& st, const string& ns)
+    SymbolTable& st, const string& ns, size_t depth, size_t maxDepth)
 {
     Object::const_iterator it = findField(e, m, "values");
 
     NodePtr node = NodePtr(new NodeMap(
-        asSingleAttribute(makeNode(it->second, st, ns))));
+        asSingleAttribute(makeNode(it->second, st, ns, depth + 1, maxDepth))));
     if (containsField(m, "doc")) {
         node->setDoc(getDocField(e, m));
     }
@@ -458,7 +461,7 @@ static Name getName(const Entity& e, const Object& m, const string& ns)
 }
 
 static NodePtr makeNode(const Entity& e, const Object& m,
-    SymbolTable& st, const string& ns)
+    SymbolTable& st, const string& ns, size_t depth, size_t maxDepth)
 {
     const string& type = getStringField(e, m, "type");
     NodePtr result;
@@ -472,12 +475,14 @@ static NodePtr makeNode(const Entity& e, const Object& m,
             if (containsField(m, "doc")) {
                 string doc = getDocField(e, m);
 
-                NodePtr r = makeRecordNode(e, nm, &doc, m, st, nm.ns());
+                NodePtr r = makeRecordNode(e, nm, &doc, m, st, nm.ns(),
+                    depth + 1, maxDepth);
                 (std::dynamic_pointer_cast<NodeRecord>(r))->swap(
                     *std::dynamic_pointer_cast<NodeRecord>(result));
             } else {  // No doc
                 NodePtr r =
-                    makeRecordNode(e, nm, NULL, m, st, nm.ns());
+                    makeRecordNode(e, nm, NULL, m, st, nm.ns(),
+                        depth + 1, maxDepth);
                 (std::dynamic_pointer_cast<NodeRecord>(r))
                     ->swap(*std::dynamic_pointer_cast<NodeRecord>(result));
             }
@@ -487,9 +492,9 @@ static NodePtr makeNode(const Entity& e, const Object& m,
             st[nm] = result;
         }
     } else if (type == "array") {
-        result = makeArrayNode(e, m, st, ns);
+        result = makeArrayNode(e, m, st, ns, depth, maxDepth);
     } else if (type == "map") {
-        result = makeMapNode(e, m, st, ns);
+        result = makeMapNode(e, m, st, ns, depth, maxDepth);
     } else {
         result = makePrimitive(type);
     }
@@ -509,35 +514,40 @@ static NodePtr makeNode(const Entity& e, const Object& m,
 }
 
 static NodePtr makeNode(const Entity& e, const Array& m,
-    SymbolTable& st, const string& ns)
+    SymbolTable& st, const string& ns, size_t depth, size_t maxDepth)
 {
     concepts::MultiAttribute<NodePtr> mm;
     for (Array::const_iterator it = m.begin(); it != m.end(); ++it) {
-        mm.add(makeNode(*it, st, ns));
+        mm.add(makeNode(*it, st, ns, depth + 1, maxDepth));
     }
     return NodePtr(new NodeUnion(mm));
 }
 
-static NodePtr makeNode(const json::Entity& e, SymbolTable& st, const string& ns)
+static NodePtr makeNode(const json::Entity& e, SymbolTable& st, const string& ns,
+    size_t depth, size_t maxDepth)
 {
+    if (maxDepth > 0 && depth > maxDepth) {
+        throw Exception("Avro schema nesting depth exceeds the limit");
+    }
+
     switch (e.type()) {
     case json::etString:
         return makeNode(e.stringValue(), st, ns);
     case json::etObject:
-        return makeNode(e, e.objectValue(), st, ns);
+        return makeNode(e, e.objectValue(), st, ns, depth, maxDepth);
     case json::etArray:
-        return makeNode(e, e.arrayValue(), st, ns);
+        return makeNode(e, e.arrayValue(), st, ns, depth, maxDepth);
     default:
         throw Exception(boost::format("Invalid Avro type: %1%") % e.toString());
     }
 }
 
-ValidSchema compileJsonSchemaFromStream(InputStream& is)
+ValidSchema compileJsonSchemaFromStream(InputStream& is, size_t maxDepth)
 {
-    json::Entity e = json::loadEntity(is);
+    json::Entity e = json::loadEntity(is, maxDepth);
     SymbolTable st;
-    NodePtr n = makeNode(e, st, "");
-    return ValidSchema(n);
+    NodePtr n = makeNode(e, st, "", 0, maxDepth);
+    return ValidSchema(n, maxDepth);
 }
 
 AVRO_DECL ValidSchema compileJsonSchemaFromFile(const char* filename)
@@ -546,36 +556,39 @@ AVRO_DECL ValidSchema compileJsonSchemaFromFile(const char* filename)
     return compileJsonSchemaFromStream(*s);
 }
 
-AVRO_DECL ValidSchema compileJsonSchemaFromMemory(const uint8_t* input, size_t len)
+AVRO_DECL ValidSchema compileJsonSchemaFromMemory(const uint8_t* input, size_t len,
+    size_t maxDepth)
 {
-    return compileJsonSchemaFromStream(*memoryInputStream(input, len));
+    return compileJsonSchemaFromStream(*memoryInputStream(input, len), maxDepth);
 }
 
-AVRO_DECL ValidSchema compileJsonSchemaFromString(const char* input)
+AVRO_DECL ValidSchema compileJsonSchemaFromString(const char* input,
+    size_t maxDepth)
 {
     return compileJsonSchemaFromMemory(reinterpret_cast<const uint8_t*>(input),
-        ::strlen(input));
+        ::strlen(input), maxDepth);
 }
 
-AVRO_DECL ValidSchema compileJsonSchemaFromString(const string& input)
+AVRO_DECL ValidSchema compileJsonSchemaFromString(const string& input,
+    size_t maxDepth)
 {
     return compileJsonSchemaFromMemory(
-        reinterpret_cast<const uint8_t*>(input.data()), input.size());
+        reinterpret_cast<const uint8_t*>(input.data()), input.size(), maxDepth);
 }
 
-static ValidSchema compile(std::istream& is)
+static ValidSchema compile(std::istream& is, size_t maxDepth = 0)
 {
     std::unique_ptr<InputStream> in = istreamInputStream(is);
-    return compileJsonSchemaFromStream(*in);
+    return compileJsonSchemaFromStream(*in, maxDepth);
 }
 
-void compileJsonSchema(std::istream &is, ValidSchema &schema)
+void compileJsonSchema(std::istream &is, ValidSchema &schema, size_t maxDepth)
 {
     if (!is.good()) {
         throw Exception("Input stream is not good");
     }
 
-    schema = compile(is);
+    schema = compile(is, maxDepth);
 }
 
 AVRO_DECL bool compileJsonSchema(std::istream &is, ValidSchema &schema, string &error)

--- a/lang/c++/impl/DataFile.cc
+++ b/lang/c++/impl/DataFile.cc
@@ -293,17 +293,20 @@ void DataFileWriterBase::setMetadata(const string& key, const string& value)
     metadata_[key] = v;
 }
 
-DataFileReaderBase::DataFileReaderBase(const char* filename) :
+DataFileReaderBase::DataFileReaderBase(const char* filename,
+    size_t maxSchemaDepth) :
     filename_(filename), stream_(fileSeekableInputStream(filename)),
     decoder_(binaryDecoder()), objectCount_(0), eof_(false), blockStart_(-1),
-    blockEnd_(-1)
+    blockEnd_(-1), maxSchemaDepth_(maxSchemaDepth)
 {
     readHeader();
 }
 
-DataFileReaderBase::DataFileReaderBase(std::unique_ptr<InputStream> inputStream) :
+DataFileReaderBase::DataFileReaderBase(std::unique_ptr<InputStream> inputStream,
+    size_t maxSchemaDepth) :
     filename_(""), stream_(std::move(inputStream)),
-    decoder_(binaryDecoder()), objectCount_(0), eof_(false)
+    decoder_(binaryDecoder()), objectCount_(0), eof_(false),
+    maxSchemaDepth_(maxSchemaDepth)
 {
     readHeader();
 }
@@ -517,11 +520,11 @@ static string toString(const vector<uint8_t>& v)
     return result;
 }
 
-static ValidSchema makeSchema(const vector<uint8_t>& v)
+static ValidSchema makeSchema(const vector<uint8_t>& v, size_t maxDepth = 0)
 {
     istringstream iss(toString(v));
     ValidSchema vs;
-    compileJsonSchema(iss, vs);
+    compileJsonSchema(iss, vs, maxDepth);
     return ValidSchema(vs);
 }
 
@@ -540,7 +543,7 @@ void DataFileReaderBase::readHeader()
         throw Exception("No schema in metadata");
     }
 
-    dataSchema_ = makeSchema(it->second);
+    dataSchema_ = makeSchema(it->second, maxSchemaDepth_);
     if (! readerSchema_.root()) {
         readerSchema_ = dataSchema();
     }

--- a/lang/c++/impl/ValidSchema.cc
+++ b/lang/c++/impl/ValidSchema.cc
@@ -34,8 +34,13 @@ using std::static_pointer_cast;
 namespace avro {
 typedef std::map<Name, NodePtr> SymbolMap;
 
-static bool validate(const NodePtr &node, SymbolMap &symbolMap)
+static bool validate(const NodePtr &node, SymbolMap &symbolMap,
+    size_t depth, size_t maxDepth)
 {
+    if (maxDepth > 0 && depth > maxDepth) {
+        throw Exception("Avro schema nesting depth exceeds the limit");
+    }
+
     if (! node->isValid()) {
         throw Exception(format("Schema is invalid, due to bad node of type %1%")
             % node->type());
@@ -71,7 +76,7 @@ static bool validate(const NodePtr &node, SymbolMap &symbolMap)
     for (size_t i = 0; i < leaves; ++i) {
         const NodePtr &leaf(node->leafAt(i));
 
-        if (! validate(leaf, symbolMap)) {
+        if (! validate(leaf, symbolMap, depth + 1, maxDepth)) {
 
             // if validate returns false it means a node with this name already
             // existed in the map, instead of keeping this node twice in the
@@ -86,20 +91,20 @@ static bool validate(const NodePtr &node, SymbolMap &symbolMap)
     return true;
 }
 
-static void validate(const NodePtr& p)
+static void validate(const NodePtr& p, size_t maxDepth = 0)
 {
     SymbolMap m;
-    validate(p, m);
+    validate(p, m, 0, maxDepth);
 }
 
-ValidSchema::ValidSchema(const NodePtr &root) : root_(root)
+ValidSchema::ValidSchema(const NodePtr &root, size_t maxDepth) : root_(root)
 {
-    validate(root_);
+    validate(root_, maxDepth);
 }
 
-ValidSchema::ValidSchema(const Schema &schema) : root_(schema.root())
+ValidSchema::ValidSchema(const Schema &schema, size_t maxDepth) : root_(schema.root())
 {
-    validate(root_);
+    validate(root_, maxDepth);
 }
 
 ValidSchema::ValidSchema() : root_(NullSchema().root())

--- a/lang/c++/impl/json/JsonDom.cc
+++ b/lang/c++/impl/json/JsonDom.cc
@@ -44,8 +44,12 @@ const char* typeToString(EntityType t)
     }
 }
 
-Entity readEntity(JsonParser& p)
+static Entity readEntityImpl(JsonParser& p, size_t depth, size_t maxDepth)
 {
+    if (maxDepth > 0 && depth > maxDepth) {
+        throw Exception("JSON nesting depth exceeds the limit");
+    }
+
     switch (p.peek()) {
     case JsonParser::tkNull:
         p.advance();
@@ -68,7 +72,7 @@ Entity readEntity(JsonParser& p)
             p.advance();
             std::shared_ptr<Array> v = std::make_shared<Array>();
             while (p.peek() != JsonParser::tkArrayEnd) {
-                v->push_back(readEntity(p));
+                v->push_back(readEntityImpl(p, depth + 1, maxDepth));
             }
             p.advance();
             return Entity(v, l);
@@ -81,7 +85,7 @@ Entity readEntity(JsonParser& p)
             while (p.peek() != JsonParser::tkObjectEnd) {
                 p.advance();
                 std::string k = p.stringValue();
-                Entity n = readEntity(p);
+                Entity n = readEntityImpl(p, depth + 1, maxDepth);
                 v->insert(std::make_pair(k, n));
             }
             p.advance();
@@ -90,25 +94,29 @@ Entity readEntity(JsonParser& p)
     default:
         throw std::domain_error(JsonParser::toString(p.peek()));
     }
-
 }
 
-Entity loadEntity(const char* text)
+Entity readEntity(JsonParser& p, size_t maxDepth)
 {
-    return loadEntity(reinterpret_cast<const uint8_t*>(text), ::strlen(text));
+    return readEntityImpl(p, 0, maxDepth);
 }
 
-Entity loadEntity(InputStream& in)
+Entity loadEntity(const char* text, size_t maxDepth)
+{
+    return loadEntity(reinterpret_cast<const uint8_t*>(text), ::strlen(text), maxDepth);
+}
+
+Entity loadEntity(InputStream& in, size_t maxDepth)
 {
     JsonParser p;
     p.init(in);
-    return readEntity(p);
+    return readEntity(p, maxDepth);
 }
 
-Entity loadEntity(const uint8_t* text, size_t len)
+Entity loadEntity(const uint8_t* text, size_t len, size_t maxDepth)
 {
     std::unique_ptr<InputStream> in = memoryInputStream(text, len);
-    return loadEntity(*in);
+    return loadEntity(*in, maxDepth);
 }
 
 void writeEntity(JsonGenerator<JsonNullFormatter>& g, const Entity& n)

--- a/lang/c++/impl/json/JsonDom.hh
+++ b/lang/c++/impl/json/JsonDom.hh
@@ -146,11 +146,11 @@ template <> struct type_traits<std::map<std::string, Entity> > {
     static const char* name() { return "object"; }
 };
 
-AVRO_DECL Entity readEntity(JsonParser& p);
+AVRO_DECL Entity readEntity(JsonParser& p, size_t maxDepth = 0);
 
-AVRO_DECL Entity loadEntity(InputStream& in);
-AVRO_DECL Entity loadEntity(const char* text);
-AVRO_DECL Entity loadEntity(const uint8_t* text, size_t len);
+AVRO_DECL Entity loadEntity(InputStream& in, size_t maxDepth = 0);
+AVRO_DECL Entity loadEntity(const char* text, size_t maxDepth = 0);
+AVRO_DECL Entity loadEntity(const uint8_t* text, size_t len, size_t maxDepth = 0);
 
 void writeEntity(JsonGenerator<JsonNullFormatter>& g, const Entity& n);
 


### PR DESCRIPTION
Thread a `maxDepth` parameter through the recursive schema parsing functions: JSON DOM parsing (`readEntity`), schema compilation (`makeNode`), and schema validation (`validate`). When `maxDepth` is non-zero and the recursion exceeds it, an exception is thrown instead of overflowing the stack.

The parameter defaults to 0 (unlimited) so existing callers are unaffected. Consumers that read untrusted Avro input can pass a reasonable limit (e.g. 256) via `DataFileReaderBase` or `compileJsonSchemaFromString` to protect against crafted schemas with thousands of nesting levels.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/) issues and references them in the PR title. For example, "AVRO-1234: My Avro PR"
  - https://issues.apache.org/jira/browse/AVRO-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
